### PR TITLE
build: Update WebAssembly build and publish workflows

### DIFF
--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -1,7 +1,6 @@
 name: Build WebAssembly
 on:
   push:
-  workflow_dispatch:
 
 jobs:
   build:
@@ -13,7 +12,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-      - name: Install Typescript
-        run: npm install -g typescript
-      - name: Compile
-        run: make wasm-all
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/wasm_publish.yml
+++ b/.github/workflows/wasm_publish.yml
@@ -2,6 +2,7 @@ name: Publish WebAssembly to GitHub Packages
 on:
   release:
     types: [published]
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -18,11 +19,8 @@ jobs:
           node-version: '22.x'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@takeyaqa'
-      - name: Install Typescript
-        run: npm install -g typescript
-      - name: Compile
-        run: make wasm-all
       - run: npm ci
+      - run: npm run build
       - run: npm publish --workspaces
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,19 @@
 {
   "name": "@takeyaqa/pict",
+  "version": "3.7.4-fork.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@takeyaqa/pict",
+      "version": "3.7.4-fork.2",
       "workspaces": [
         "packages/pict-browser",
         "packages/pict-node"
-      ]
+      ],
+      "devDependencies": {
+        "typescript": "^5.8.3"
+      }
     },
     "node_modules/@takeyaqa/pict-browser": {
       "resolved": "packages/pict-browser",
@@ -18,14 +23,28 @@
       "resolved": "packages/pict-node",
       "link": true
     },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/pict-browser": {
       "name": "@takeyaqa/pict-browser",
-      "version": "3.7.4-fork.1",
+      "version": "3.7.4-fork.2",
       "license": "MIT"
     },
     "packages/pict-node": {
       "name": "@takeyaqa/pict-node",
-      "version": "3.7.4-fork.1",
+      "version": "3.7.4-fork.2",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@takeyaqa/pict",
   "private": true,
+  "version": "3.7.4-fork.2",
+  "scripts": {
+    "build": "make wasm-all",
+    "clean": "make wasm-clean"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
   "workspaces": [
     "packages/pict-browser",
     "packages/pict-node"

--- a/packages/pict-browser/package.json
+++ b/packages/pict-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict-browser",
   "description": "Pairwise Independent Combinatorial Testing for Browser",
-  "version": "3.7.4-fork.1",
+  "version": "3.7.4-fork.2",
   "scripts": {
     "prepack": "cp ../../README.md . && cp ../../LICENSE.TXT .",
     "postpack": "rm README.md LICENSE.TXT"
@@ -12,7 +12,10 @@
     "dist"
   ],
   "types": "dist/index.d.ts",
-  "repository": "https://github.com/takeyaqa/pict",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/takeyaqa/pict.git"
+  },
   "author": "Microsoft Corporation",
   "license": "MIT",
   "bugs": {

--- a/packages/pict-node/package.json
+++ b/packages/pict-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict-node",
   "description": "Pairwise Independent Combinatorial Testing for Node.js",
-  "version": "3.7.4-fork.1",
+  "version": "3.7.4-fork.2",
   "scripts": {
     "prepack": "cp ../../README.md . && cp ../../LICENSE.TXT .",
     "postpack": "rm README.md LICENSE.TXT"
@@ -12,7 +12,10 @@
     "dist"
   ],
   "types": "dist/index.d.ts",
-  "repository": "https://github.com/takeyaqa/pict",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/takeyaqa/pict.git"
+  },
   "author": "Microsoft Corporation",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This pull request updates the WebAssembly build and publish workflows, centralizes build-related scripts in `package.json`, and standardizes metadata across package files. The most important changes are grouped below by theme.

### Workflow Improvements:
* [`.github/workflows/wasm_build.yml`](diffhunk://#diff-f152fd972a49e781d7c3365ad4f985c073ce34dea9db832a08800b473f1891faL4): Simplified the build workflow by replacing manual TypeScript installation and compilation steps with `npm ci` and `npm run build`. Removed the `workflow_dispatch` trigger. [[1]](diffhunk://#diff-f152fd972a49e781d7c3365ad4f985c073ce34dea9db832a08800b473f1891faL4) [[2]](diffhunk://#diff-f152fd972a49e781d7c3365ad4f985c073ce34dea9db832a08800b473f1891faL16-R16)
* [`.github/workflows/wasm_publish.yml`](diffhunk://#diff-8b0e7d420d6dc29894f9115e65f12ab3f13d30a73a46f37cbdfa6daad107513dR5): Updated the publish workflow to use `npm run build` instead of manual TypeScript installation and compilation. Added `npm ci` step for dependency installation. [[1]](diffhunk://#diff-8b0e7d420d6dc29894f9115e65f12ab3f13d30a73a46f37cbdfa6daad107513dR5) [[2]](diffhunk://#diff-8b0e7d420d6dc29894f9115e65f12ab3f13d30a73a46f37cbdfa6daad107513dL21-R23)

### Centralized Build Scripts:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R4-R11): Added `build` and `clean` scripts to centralize WebAssembly build commands. Declared `typescript` as a `devDependency`.

### Metadata Standardization:
* `packages/pict-browser/package.json` and `packages/pict-node/package.json`: Updated the `version` field to `3.7.4-fork.2` and replaced the `repository` field with a structured object containing `type` and `url`. [[1]](diffhunk://#diff-954bf1d5c0a690fd7fa25b0fc381ebb1b24ce1289a85ba8a9da21b2cad5714cfL4-R4) [[2]](diffhunk://#diff-954bf1d5c0a690fd7fa25b0fc381ebb1b24ce1289a85ba8a9da21b2cad5714cfL15-R18) [[3]](diffhunk://#diff-bb216cf3556ccd26dfb23f78ce1c2a1fe631ab060f5276468a3aebff42c764d5L4-R4) [[4]](diffhunk://#diff-bb216cf3556ccd26dfb23f78ce1c2a1fe631ab060f5276468a3aebff42c764d5L15-R18)