### PR TITLE
build: Update package versions to 3.7.4-fork.3 and adjust npm publish command

### DIFF
--- a/.github/workflows/wasm_publish.yml
+++ b/.github/workflows/wasm_publish.yml
@@ -8,19 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     container: emscripten/emsdk:4.0.7
 
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@takeyaqa'
       - run: npm ci
       - run: npm run build
-      - run: npm publish --workspaces
+      - run: npm publish --workspaces --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@takeyaqa/pict",
-  "version": "3.7.4-fork.2",
+  "version": "3.7.4-fork.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@takeyaqa/pict",
-      "version": "3.7.4-fork.2",
+      "version": "3.7.4-fork.3",
       "workspaces": [
         "packages/pict-browser",
         "packages/pict-node"
@@ -39,12 +39,12 @@
     },
     "packages/pict-browser": {
       "name": "@takeyaqa/pict-browser",
-      "version": "3.7.4-fork.2",
+      "version": "3.7.4-fork.3",
       "license": "MIT"
     },
     "packages/pict-node": {
       "name": "@takeyaqa/pict-node",
-      "version": "3.7.4-fork.2",
+      "version": "3.7.4-fork.3",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict",
   "private": true,
-  "version": "3.7.4-fork.2",
+  "version": "3.7.4-fork.3",
   "scripts": {
     "build": "make wasm-all",
     "clean": "make wasm-clean"

--- a/packages/pict-browser/package.json
+++ b/packages/pict-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict-browser",
   "description": "Pairwise Independent Combinatorial Testing for Browser",
-  "version": "3.7.4-fork.2",
+  "version": "3.7.4-fork.3",
   "scripts": {
     "prepack": "cp ../../README.md . && cp ../../LICENSE.TXT .",
     "postpack": "rm README.md LICENSE.TXT"

--- a/packages/pict-node/package.json
+++ b/packages/pict-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict-node",
   "description": "Pairwise Independent Combinatorial Testing for Node.js",
-  "version": "3.7.4-fork.2",
+  "version": "3.7.4-fork.3",
   "scripts": {
     "prepack": "cp ../../README.md . && cp ../../LICENSE.TXT .",
     "postpack": "rm README.md LICENSE.TXT"


### PR DESCRIPTION
This pull request updates the publishing workflow and increments the version numbers for several packages. The most important changes include modifying the `wasm_publish.yml` workflow to use a different token and adjust the publish access level, as well as updating the version numbers in `package.json` files for consistency.

### Workflow updates:
* [`.github/workflows/wasm_publish.yml`](diffhunk://#diff-8b0e7d420d6dc29894f9115e65f12ab3f13d30a73a46f37cbdfa6daad107513dL11-R20): Updated the `npm publish` command to include `--access public` and replaced the `NODE_AUTH_TOKEN` environment variable to use `secrets.NPM_TOKEN` instead of `secrets.GITHUB_TOKEN`. Removed unused permissions and registry configuration.

### Version updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Incremented the version from `3.7.4-fork.2` to `3.7.4-fork.3`.
* [`packages/pict-browser/package.json`](diffhunk://#diff-954bf1d5c0a690fd7fa25b0fc381ebb1b24ce1289a85ba8a9da21b2cad5714cfL4-R4): Incremented the version from `3.7.4-fork.2` to `3.7.4-fork.3`.
* [`packages/pict-node/package.json`](diffhunk://#diff-bb216cf3556ccd26dfb23f78ce1c2a1fe631ab060f5276468a3aebff42c764d5L4-R4): Incremented the version from `3.7.4-fork.2` to `3.7.4-fork.3`.