### PR TITLE
build: Update package version to 3.7.4-fork.4

### DIFF
--- a/.github/workflows/wasm_publish.yml
+++ b/.github/workflows/wasm_publish.yml
@@ -15,6 +15,6 @@ jobs:
           node-version: '22.x'
       - run: npm ci
       - run: npm run build
-      - run: npm publish --workspaces --access public
+      - run: npm publish --workspaces
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@takeyaqa/pict",
-  "version": "3.7.4-fork.3",
+  "version": "3.7.4-fork.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@takeyaqa/pict",
-      "version": "3.7.4-fork.3",
+      "version": "3.7.4-fork.4",
       "workspaces": [
         "packages/pict-browser",
         "packages/pict-node"
@@ -39,12 +39,12 @@
     },
     "packages/pict-browser": {
       "name": "@takeyaqa/pict-browser",
-      "version": "3.7.4-fork.3",
+      "version": "3.7.4-fork.4",
       "license": "MIT"
     },
     "packages/pict-node": {
       "name": "@takeyaqa/pict-node",
-      "version": "3.7.4-fork.3",
+      "version": "3.7.4-fork.4",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict",
   "private": true,
-  "version": "3.7.4-fork.3",
+  "version": "3.7.4-fork.4",
   "scripts": {
     "build": "make wasm-all",
     "clean": "make wasm-clean"

--- a/packages/pict-browser/package.json
+++ b/packages/pict-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict-browser",
   "description": "Pairwise Independent Combinatorial Testing for Browser",
-  "version": "3.7.4-fork.3",
+  "version": "3.7.4-fork.4",
   "scripts": {
     "prepack": "cp ../../README.md . && cp ../../LICENSE.TXT .",
     "postpack": "rm README.md LICENSE.TXT"

--- a/packages/pict-node/package.json
+++ b/packages/pict-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict-node",
   "description": "Pairwise Independent Combinatorial Testing for Node.js",
-  "version": "3.7.4-fork.3",
+  "version": "3.7.4-fork.4",
   "scripts": {
     "prepack": "cp ../../README.md . && cp ../../LICENSE.TXT .",
     "postpack": "rm README.md LICENSE.TXT"


### PR DESCRIPTION
This pull request includes updates to the versioning of the `@takeyaqa/pict` packages and a modification to the publishing workflow in the GitHub Actions configuration. These changes ensure proper versioning for the packages and simplify the npm publishing process.

### Version updates:
* Updated the version in `package.json` from `3.7.4-fork.3` to `3.7.4-fork.4` for the main package (`package.json`).
* Updated the version in `packages/pict-browser/package.json` from `3.7.4-fork.3` to `3.7.4-fork.4` for the browser-specific package.
* Updated the version in `packages/pict-node/package.json` from `3.7.4-fork.3` to `3.7.4-fork.4` for the Node.js-specific package.

### Workflow updates:
* Removed the `--access public` flag from the `npm publish` command in `.github/workflows/wasm_publish.yml` to simplify the publishing process.