### PR TITLE
build: update package version to 3.7.4-fork.5

### DIFF
--- a/.github/workflows/wasm_publish.yml
+++ b/.github/workflows/wasm_publish.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
       - run: npm publish --workspaces

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@takeyaqa/pict",
-  "version": "3.7.4-fork.4",
+  "version": "3.7.4-fork.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@takeyaqa/pict",
-      "version": "3.7.4-fork.4",
+      "version": "3.7.4-fork.5",
       "workspaces": [
         "packages/pict-browser",
         "packages/pict-node"
@@ -39,12 +39,12 @@
     },
     "packages/pict-browser": {
       "name": "@takeyaqa/pict-browser",
-      "version": "3.7.4-fork.4",
+      "version": "3.7.4-fork.5",
       "license": "MIT"
     },
     "packages/pict-node": {
       "name": "@takeyaqa/pict-node",
-      "version": "3.7.4-fork.4",
+      "version": "3.7.4-fork.5",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict",
   "private": true,
-  "version": "3.7.4-fork.4",
+  "version": "3.7.4-fork.5",
   "scripts": {
     "build": "make wasm-all",
     "clean": "make wasm-clean"

--- a/packages/pict-browser/package.json
+++ b/packages/pict-browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict-browser",
   "description": "Pairwise Independent Combinatorial Testing for Browser",
-  "version": "3.7.4-fork.4",
+  "version": "3.7.4-fork.5",
   "scripts": {
     "prepack": "cp ../../README.md . && cp ../../LICENSE.TXT .",
     "postpack": "rm README.md LICENSE.TXT"

--- a/packages/pict-node/package.json
+++ b/packages/pict-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@takeyaqa/pict-node",
   "description": "Pairwise Independent Combinatorial Testing for Node.js",
-  "version": "3.7.4-fork.4",
+  "version": "3.7.4-fork.5",
   "scripts": {
     "prepack": "cp ../../README.md . && cp ../../LICENSE.TXT .",
     "postpack": "rm README.md LICENSE.TXT"


### PR DESCRIPTION
This pull request includes updates to the workflow configuration and version bumps for several `package.json` files. The most important changes ensure compatibility with the npm registry and prepare the packages for a new release.

### Workflow configuration updates:
* [`.github/workflows/wasm_publish.yml`](diffhunk://#diff-8b0e7d420d6dc29894f9115e65f12ab3f13d30a73a46f37cbdfa6daad107513dR16): Added the `registry-url` parameter to the `setup-node` action to specify the npm registry URL, ensuring proper publishing behavior.

### Version updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `3.7.4-fork.4` to `3.7.4-fork.5` to reflect the new release.
* [`packages/pict-browser/package.json`](diffhunk://#diff-954bf1d5c0a690fd7fa25b0fc381ebb1b24ce1289a85ba8a9da21b2cad5714cfL4-R4): Updated the version from `3.7.4-fork.4` to `3.7.4-fork.5` for the browser-specific package.
* [`packages/pict-node/package.json`](diffhunk://#diff-bb216cf3556ccd26dfb23f78ce1c2a1fe631ab060f5276468a3aebff42c764d5L4-R4): Updated the version from `3.7.4-fork.4` to `3.7.4-fork.5` for the Node.js-specific package.